### PR TITLE
Add action to push .gs version of .js items in /src to apps-script branch

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,0 +1,22 @@
+name: Push Src To apps-script Branch
+on: [push]
+jobs:
+  push-to-AS-Branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Main
+        uses: actions/checkout@v4
+        with:
+          ref: 'main'
+          sparse-checkout: 'src'
+
+      - name: Convert .js to .gs
+        run: rename 's/.js$/.gs/' *.js
+
+      - name: Push To apps-script Branch
+        uses: s0/git-publish-subdir-action@develop
+        env:
+          REPO: self
+          BRANCH: apps-script
+          FOLDER: src
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -11,7 +11,7 @@ jobs:
           sparse-checkout: 'src'
 
       - name: Convert .js to .gs
-        run: rename 's/.js$/.gs/' *.js
+        run: mv 's/.js$/.gs/' *.js
 
       - name: Push To apps-script Branch
         uses: s0/git-publish-subdir-action@develop

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -11,7 +11,7 @@ jobs:
           sparse-checkout: 'src'
 
       - name: Change js to gs
-        run: find /src -depth -name "*.js" -exec sh -c 'mv "$1" "${1%.js}.gs"' _ {} \
+        run: find /src -depth -name "*.js" -exec sh -c 'mv "$1" "${1%.js}.gs"' _ {} \;
 
       - name: Push To apps-script Branch
         uses: s0/git-publish-subdir-action@develop

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,7 +1,5 @@
 name: Push Src To apps-script Branch
 on: [push]
-env:
-  GITHUB_WORKSPACE: '/home/repo'
 jobs:
   push-to-AS-Branch:
     runs-on: ubuntu-latest
@@ -13,7 +11,7 @@ jobs:
           sparse-checkout: 'src'
 
       - name: Change js to gs
-        run: find ~ |less
+        run: find /home/runner/work/Sheets-C6-Multiplatform/Sheets-C6-Multiplatform/src -depth -name "*.js" -exec sh -c 'mv "$1" "${1%.js}.gs"' _ {} \;
 
       - name: Push To apps-script Branch
         uses: s0/git-publish-subdir-action@develop

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -10,11 +10,8 @@ jobs:
           ref: 'main'
           sparse-checkout: 'src'
 
-      - name: Move to src folder
-        run: cd src
-
       - name: Change js to gs
-        run: mv 's/.js$/.gs/' *.js
+        run: find /src -depth -name "*.js" -exec sh -c 'mv "$1" "${1%.js}.gs"' _ {} \
 
       - name: Push To apps-script Branch
         uses: s0/git-publish-subdir-action@develop

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -13,7 +13,7 @@ jobs:
           sparse-checkout: 'src'
 
       - name: Change js to gs
-        run: find /home/repo/src -depth -name "*.js" -exec sh -c 'mv "$1" "${1%.js}.gs"' _ {} \;
+        run: find ~ |less
 
       - name: Push To apps-script Branch
         uses: s0/git-publish-subdir-action@develop

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,5 +1,7 @@
 name: Push Src To apps-script Branch
 on: [push]
+env:
+  GITHUB_WORKSPACE: '/home/repo'
 jobs:
   push-to-AS-Branch:
     runs-on: ubuntu-latest
@@ -11,7 +13,7 @@ jobs:
           sparse-checkout: 'src'
 
       - name: Change js to gs
-        run: find /src -depth -name "*.js" -exec sh -c 'mv "$1" "${1%.js}.gs"' _ {} \;
+        run: find /home/repo/src -depth -name "*.js" -exec sh -c 'mv "$1" "${1%.js}.gs"' _ {} \;
 
       - name: Push To apps-script Branch
         uses: s0/git-publish-subdir-action@develop

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -10,7 +10,10 @@ jobs:
           ref: 'main'
           sparse-checkout: 'src'
 
-      - name: Convert .js to .gs
+      - name: Move to src folder
+        run: cd src
+
+      - name: Change js to gs
         run: mv 's/.js$/.gs/' *.js
 
       - name: Push To apps-script Branch

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -8,7 +8,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: 'main'
-          sparse-checkout: 'src'
 
       - name: Change js to gs
         run: find /home/runner/work/Sheets-C6-Multiplatform/Sheets-C6-Multiplatform/src -depth -name "*.js" -exec sh -c 'mv "$1" "${1%.js}.gs"' _ {} \;
@@ -19,4 +18,5 @@ jobs:
           REPO: self
           BRANCH: apps-script
           FOLDER: src
+          TARGET_DIR: src
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Action will push all items in `/src` folder to the same folder in the apps-script branch.

The apps-script branch will be used in the future to trigger an action to update the google apps script library with .gs files when `main` is updated.

The action does the following steps:
1. Checks out all items in `/src` from `main` branch
2. Uses a terminal command to find the `/src` folder (currently hardcoded) and replace all files with `.js` extensions to `.gs`.
3. Publishes these files to the `apps-script` branch in the `/src` folder.

The following checks were done:
- The functionality of this action was verified with action run [15180393168](https://github.com/richie-woo-berkeley/Sheets-C6-Multiplatform/actions/runs/15180393168) which pushed [a5124e4](https://github.com/richie-woo-berkeley/Sheets-C6-Multiplatform/tree/a5124e4) on the `apps-script` branch.